### PR TITLE
Publisher deployment on Base Sepolia with Wormhole checkpoint

### DIFF
--- a/config/wormhole.config.ts
+++ b/config/wormhole.config.ts
@@ -4,7 +4,7 @@
  * @dev Contains Guardian RPC, consistency level, and Wormhole Core addresses
  */
 
-import { CHAIN_IDS } from "../constants/chainIds.js";
+import { CHAIN_IDS } from "../constants/chainIds.ts";
 
 /**
  * @notice Chain-specific Wormhole configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -2088,18 +2088,13 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.10.12",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.10.12.tgz",
-      "integrity": "sha512-tTHyLls1Nik5QTs/S03qqG2y/ITvNwI8CJOQbMmmsr1CL2CdjJBtzRYn9Dyx2p8XgzRFf9hmlybpe20tq9O3SA==",
-      "hasInstallScript": true,
+      "version": "1.16.21",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.21.tgz",
+      "integrity": "sha512-ARPFvhNuui3YGmtysTtqeLpdLu5OtfwQ9+OxaTulXjn5Frf3/RvHBtBr7Ja0ofLIPuzhlTqEvTiLQfNJJUV20Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.10.12",
-        "@injectivelabs/ts-types": "^1.10.12",
-        "@injectivelabs/utils": "^1.10.12",
-        "link-module-alias": "^1.2.0",
-        "shx": "^0.3.2"
+        "@injectivelabs/ts-types": "1.16.21"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
@@ -2177,16 +2172,6 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/test-utils/node_modules/@injectivelabs/networks": {
-      "version": "1.16.21",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.21.tgz",
-      "integrity": "sha512-ARPFvhNuui3YGmtysTtqeLpdLu5OtfwQ9+OxaTulXjn5Frf3/RvHBtBr7Ja0ofLIPuzhlTqEvTiLQfNJJUV20Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@injectivelabs/ts-types": "1.16.21"
-      }
-    },
     "node_modules/@injectivelabs/test-utils/node_modules/@injectivelabs/utils": {
       "version": "1.16.21",
       "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.16.21.tgz",
@@ -2251,16 +2236,6 @@
         "lodash": "^4.17.21",
         "lodash.values": "^4.3.0",
         "shx": "^0.3.2"
-      }
-    },
-    "node_modules/@injectivelabs/token-metadata/node_modules/@injectivelabs/networks": {
-      "version": "1.16.21",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.16.21.tgz",
-      "integrity": "sha512-ARPFvhNuui3YGmtysTtqeLpdLu5OtfwQ9+OxaTulXjn5Frf3/RvHBtBr7Ja0ofLIPuzhlTqEvTiLQfNJJUV20Q==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@injectivelabs/ts-types": "1.16.21"
       }
     },
     "node_modules/@injectivelabs/token-metadata/node_modules/@injectivelabs/utils": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ethers": "5.8.0"
   },
   "overrides": {
-    "ethers": "5.8.0"
+    "ethers": "5.8.0",
+    "@injectivelabs/networks": "1.16.21"
   }
 }

--- a/scripts/publisher.ts
+++ b/scripts/publisher.ts
@@ -11,6 +11,8 @@ import {
 } from "@certusone/wormhole-sdk";
 
 dotenv.config();
+console.log("RPC_URL loaded:", process.env.RPC_URL?.slice(0, 20) + "..."); // only first part for safety
+console.log("PRIVATE_KEY loaded:", !!process.env.PRIVATE_KEY);
 
 const RPC_URL = process.env.RPC_URL!;
 const PRIVATE_KEY = process.env.PRIVATE_KEY!;
@@ -90,12 +92,15 @@ export async function publishCheckpoint(
 }
 
 // Run with: npx ts-node scripts/publisher.ts
-if (process.argv[1] === new URL(import.meta.url).pathname) {
-  (async () => {
+(async () => {
+  try {
     const cid = "bafyExampleCid123";
     const tag = ethers.utils.formatBytes32String("file1");
     const expiresAt = Math.floor(Date.now() / 1000) + 3600;
 
-    await publishCheckpoint(cid, tag, expiresAt);
-  })();
-}
+    const result = await publishCheckpoint(cid, tag, expiresAt);
+    console.log("✅ Publisher result:", result);
+  } catch (err) {
+    console.error("❌ Error running publisher:", err);
+  }
+})();


### PR DESCRIPTION
Deploys the Publisher contract on Base Sepolia testnet and publishes a checkpoint to Wormhole, setting up the foundation for cross-chain testing with the Receiver on Avalanche Fuji.

## Type of Change

* [x] New feature (adds functionality for Publisher deployment and checkpoint publication)

## Changes Made

* Added Publisher deployment script (`scripts/publisher.ts`)
* Configured script to encode and publish checkpoints to Wormhole
* Verified successful publication with emitter and sequence logs

## Testing

* [x] Manual testing completed on Base Sepolia testnet
* [x] Checkpoint publishing confirmed in console output

## Checklist

* [x] Code follows project’s style guidelines
* [x] Self-review of code completed
* [x] Documentation updated in comments for clarity


## Additional Notes

* Publisher is now ready; next step is Receiver deployment on Avalanche Fuji testnet.
* Script requires RPC URL and private key via environment variables for local testing.

