### PR TITLE
feat: create minimal ElizaOS adapter for attestation flow

### DIFF
--- a/elizaos-adapter/action.ts
+++ b/elizaos-adapter/action.ts
@@ -1,0 +1,141 @@
+/**
+ * @title createAttestationAction
+ * @notice ElizaOS action that bridges agent messages to the DataAttestation SDK.
+ */
+import { validateAttestation, normalizeAttestation } from "../sdk/index.js";
+import type { DataAttestation } from "../sdk/types.js";
+import { simulatedPublish } from "./publisher.js";
+import type {
+  Action,
+  IAgentRuntime,
+  Message,
+  ActionResult,
+  ActionCallback,
+} from "./types.js";
+
+function extractAttestation(
+  runtime: IAgentRuntime,
+  message: Message
+): DataAttestation {
+  const content = message.content;
+
+  const cid = content.cid as string | undefined;
+  if (!cid) {
+    throw new Error(
+      "Missing 'cid' in message content. Provide a Storacha CID to attest."
+    );
+  }
+
+  const creator =
+    (content.creator as string | undefined) ||
+    runtime.getSetting("ATTESTATION_CREATOR_ADDRESS");
+  if (!creator) {
+    throw new Error(
+      "Missing creator address. Set 'creator' in message content " +
+        "or configure ATTESTATION_CREATOR_ADDRESS in agent settings."
+    );
+  }
+
+  const timestamp =
+    (content.timestamp as number | undefined) ?? Math.floor(Date.now() / 1000);
+
+  const attestation: DataAttestation = {
+    cid,
+    creator,
+    timestamp,
+  };
+
+  if (content.lineage) {
+    attestation.lineage = content.lineage as string;
+  }
+  if (content.licenseHash) {
+    attestation.licenseHash = content.licenseHash as string;
+  }
+
+  return attestation;
+}
+
+export const createAttestationAction: Action = {
+  name: "CREATE_ATTESTATION",
+  description:
+    "Create a Storacha data attestation from a CID and publish it. " +
+    "Requires 'cid' in message content. Optionally accepts 'creator', " +
+    "'timestamp', 'lineage', and 'licenseHash'.",
+  similes: [
+    "ATTEST_DATA",
+    "PUBLISH_ATTESTATION",
+    "CREATE_DATA_ATTESTATION",
+    "STORACHA_ATTEST",
+  ],
+  examples: [
+    [
+      {
+        user: "agent",
+        content: {
+          text: "Create attestation for CID",
+          cid: "bafybeidataattestationexamplecidbafybeidataattestation",
+          creator: "0x1234567890123456789012345678901234567890",
+        },
+      },
+    ],
+  ],
+  validate: async (
+    _runtime: IAgentRuntime,
+    message: Message
+  ): Promise<boolean> => {
+    return (
+      typeof message.content?.cid === "string" && message.content.cid.length > 0
+    );
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Message,
+    _state?: unknown,
+    _options?: unknown,
+    callback?: ActionCallback
+  ): Promise<ActionResult> => {
+    try {
+      const attestation = extractAttestation(runtime, message);
+      validateAttestation(attestation);
+      const normalized = normalizeAttestation(attestation);
+      const result = await simulatedPublish(normalized);
+
+      if (callback) {
+        callback({
+          text: `Attestation created for CID: ${normalized.cid}`,
+          data: {
+            cid: normalized.cid,
+            creator: normalized.creator,
+            timestamp: String(normalized.timestamp),
+            payload: result.payload,
+          },
+        });
+      }
+
+      return {
+        success: true,
+        data: {
+          cid: normalized.cid,
+          creator: normalized.creator,
+          timestamp: String(normalized.timestamp),
+          payload: result.payload,
+          publishedAt: result.timestamp,
+        },
+      };
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      if (callback) {
+        callback({
+          text: `Attestation failed: ${errorMessage}`,
+        });
+      }
+
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  },
+};

--- a/elizaos-adapter/index.ts
+++ b/elizaos-adapter/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./publisher.js";
+export * from "./action.js";
+export * from "./plugin.js";

--- a/elizaos-adapter/plugin.ts
+++ b/elizaos-adapter/plugin.ts
@@ -1,0 +1,14 @@
+/**
+ * @title storachaAttestationPlugin
+ * @notice ElizaOS plugin that registers the attestation action.
+ */
+import type { Plugin } from "./types.js";
+import { createAttestationAction } from "./action.js";
+
+export const storachaAttestationPlugin: Plugin = {
+  name: "storacha-attestation",
+  description:
+    "Storacha data attestation plugin. Enables agents to create " +
+    "and publish verifiable data attestations for Storacha CIDs.",
+  actions: [createAttestationAction],
+};

--- a/elizaos-adapter/publisher.ts
+++ b/elizaos-adapter/publisher.ts
@@ -1,0 +1,33 @@
+/**
+ * @title SimulatedPublisher
+ * @notice Logs attestation payloads instead of publishing on-chain.
+ *         Replace with a real publisher for production use.
+ */
+import { encodeAttestation } from "../sdk/index.js";
+import type { DataAttestation } from "../sdk/types.js";
+
+export interface PublishResult {
+  success: boolean;
+  payload: string;
+  attestation: Required<DataAttestation>;
+  timestamp: string;
+}
+
+export async function simulatedPublish(
+  attestation: Required<DataAttestation>
+): Promise<PublishResult> {
+  const payload = encodeAttestation(attestation);
+
+  console.log("[SimulatedPublisher] Attestation encoded successfully");
+  console.log("[SimulatedPublisher] CID:", attestation.cid);
+  console.log("[SimulatedPublisher] Creator:", attestation.creator);
+  console.log("[SimulatedPublisher] Timestamp:", String(attestation.timestamp));
+  console.log("[SimulatedPublisher] Payload:", payload);
+
+  return {
+    success: true,
+    payload,
+    attestation,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/elizaos-adapter/types.ts
+++ b/elizaos-adapter/types.ts
@@ -1,0 +1,65 @@
+/**
+ * @title ElizaOS Type Stubs
+ * @notice Minimal local type definitions for ElizaOS adapter.
+ *         These avoid a hard dependency on @elizaos/core while remaining
+ *         structurally compatible with the real interfaces.
+ */
+
+export interface IAgentRuntime {
+  // eslint-disable-next-line no-unused-vars
+  getSetting(_key: string): string | undefined;
+}
+
+export interface Message {
+  content: {
+    text?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  };
+}
+
+export interface ActionResult {
+  success: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: Record<string, any>;
+  error?: string;
+}
+
+// eslint-disable-next-line no-unused-vars
+export type ActionCallback = (_response: {
+  text: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: Record<string, any>;
+}) => void;
+
+export interface Action {
+  name: string;
+  description: string;
+  similes?: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  examples?: any[];
+  validate: (
+    // eslint-disable-next-line no-unused-vars
+    _runtime: IAgentRuntime,
+    // eslint-disable-next-line no-unused-vars
+    _message: Message
+  ) => Promise<boolean>;
+  handler: (
+    // eslint-disable-next-line no-unused-vars
+    _runtime: IAgentRuntime,
+    // eslint-disable-next-line no-unused-vars
+    _message: Message,
+    // eslint-disable-next-line no-unused-vars
+    _state?: unknown,
+    // eslint-disable-next-line no-unused-vars
+    _options?: unknown,
+    // eslint-disable-next-line no-unused-vars
+    _callback?: ActionCallback
+  ) => Promise<ActionResult>;
+}
+
+export interface Plugin {
+  name: string;
+  description: string;
+  actions?: Action[];
+}

--- a/scripts/elizaos-example.ts
+++ b/scripts/elizaos-example.ts
@@ -1,0 +1,67 @@
+/**
+ * @title ElizaOS Adapter Example
+ * @notice Demonstrates how an ElizaOS agent would use the Storacha attestation plugin.
+ *
+ * Usage: npx tsx scripts/elizaos-example.ts
+ */
+import { storachaAttestationPlugin } from "../elizaos-adapter/index.js";
+import type { IAgentRuntime, Message } from "../elizaos-adapter/types.js";
+
+async function main() {
+  console.log("--- ElizaOS Adapter Example ---\n");
+
+  // 1. Show plugin info
+  const plugin = storachaAttestationPlugin;
+  console.log("Plugin:", plugin.name);
+  console.log("Description:", plugin.description);
+  console.log("Actions:", plugin.actions?.map((a) => a.name).join(", "));
+
+  // 2. Simulate an agent runtime with settings
+  const runtime: IAgentRuntime = {
+    getSetting(key: string) {
+      const settings: Record<string, string> = {
+        ATTESTATION_CREATOR_ADDRESS:
+          "0x1234567890123456789012345678901234567890",
+      };
+      return settings[key];
+    },
+  };
+
+  // 3. Simulate an incoming message with a CID
+  const message: Message = {
+    content: {
+      text: "Attest this dataset CID",
+      cid: "bafybeidataattestationexamplecidbafybeidataattestation",
+    },
+  };
+
+  const action = plugin.actions![0];
+
+  // 4. Validate
+  const isValid = await action.validate(runtime, message);
+  console.log("\nValidation passed:", isValid);
+
+  if (!isValid) {
+    console.log("Message does not contain a valid CID. Skipping.");
+    return;
+  }
+
+  // 5. Handle
+  const result = await action.handler(
+    runtime,
+    message,
+    undefined,
+    undefined,
+    (response) => {
+      console.log("\n[Agent Callback]", response.text);
+    }
+  );
+
+  console.log("\nAction result:", JSON.stringify(result, null, 2));
+  console.log("\n--- Example Complete ---");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/elizaos-adapter/ElizaOSAdapter.test.ts
+++ b/test/elizaos-adapter/ElizaOSAdapter.test.ts
@@ -1,0 +1,205 @@
+import { expect } from "chai";
+import { createAttestationAction } from "../../elizaos-adapter/action.js";
+import { storachaAttestationPlugin } from "../../elizaos-adapter/plugin.js";
+import { simulatedPublish } from "../../elizaos-adapter/publisher.js";
+import { normalizeAttestation } from "../../sdk/index.js";
+import type { IAgentRuntime, Message } from "../../elizaos-adapter/types.js";
+
+function mockRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    getSetting(key: string) {
+      return settings[key];
+    },
+  };
+}
+
+function mockMessage(content: Record<string, unknown>): Message {
+  return { content };
+}
+
+const SAMPLE_CID = "bafybeidataattestationexamplecidbafybeidataattestation";
+const SAMPLE_CREATOR = "0x1234567890123456789012345678901234567890";
+
+describe("ElizaOS Adapter", function () {
+  describe("Plugin registration", function () {
+    it("should export a plugin with the correct name", function () {
+      expect(storachaAttestationPlugin.name).to.equal("storacha-attestation");
+    });
+
+    it("should register one action", function () {
+      expect(storachaAttestationPlugin.actions).to.have.length(1);
+      expect(storachaAttestationPlugin.actions![0].name).to.equal(
+        "CREATE_ATTESTATION"
+      );
+    });
+  });
+
+  describe("Action validation", function () {
+    it("should return true when message has a CID", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({ cid: SAMPLE_CID });
+      const result = await createAttestationAction.validate(runtime, message);
+      expect(result).to.be.true;
+    });
+
+    it("should return false when message has no CID", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({ text: "hello" });
+      const result = await createAttestationAction.validate(runtime, message);
+      expect(result).to.be.false;
+    });
+
+    it("should return false when CID is empty string", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({ cid: "" });
+      const result = await createAttestationAction.validate(runtime, message);
+      expect(result).to.be.false;
+    });
+  });
+
+  describe("Action handler - success", function () {
+    it("should create attestation with explicit fields", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({
+        cid: SAMPLE_CID,
+        creator: SAMPLE_CREATOR,
+        timestamp: 1710000000,
+      });
+
+      const result = await createAttestationAction.handler(runtime, message);
+
+      expect(result.success).to.be.true;
+      expect(result.data).to.exist;
+      expect(result.data!.cid).to.equal(SAMPLE_CID);
+      expect(result.data!.creator).to.equal(SAMPLE_CREATOR);
+      expect(result.data!.payload).to.be.a("string");
+      expect((result.data!.payload as string).startsWith("0x")).to.be.true;
+    });
+
+    it("should use runtime setting for creator if not in message", async function () {
+      const runtime = mockRuntime({
+        ATTESTATION_CREATOR_ADDRESS: SAMPLE_CREATOR,
+      });
+      const message = mockMessage({ cid: SAMPLE_CID });
+
+      const result = await createAttestationAction.handler(runtime, message);
+
+      expect(result.success).to.be.true;
+      expect(result.data!.creator).to.equal(SAMPLE_CREATOR);
+    });
+
+    it("should auto-generate timestamp if not provided", async function () {
+      const before = Math.floor(Date.now() / 1000);
+      const runtime = mockRuntime({
+        ATTESTATION_CREATOR_ADDRESS: SAMPLE_CREATOR,
+      });
+      const message = mockMessage({ cid: SAMPLE_CID });
+
+      const result = await createAttestationAction.handler(runtime, message);
+      const after = Math.floor(Date.now() / 1000);
+
+      expect(result.success).to.be.true;
+      const ts = Number(result.data!.timestamp);
+      expect(ts).to.be.at.least(before);
+      expect(ts).to.be.at.most(after);
+    });
+
+    it("should invoke callback on success", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({
+        cid: SAMPLE_CID,
+        creator: SAMPLE_CREATOR,
+      });
+
+      let callbackCalled = false;
+      const callback = () => {
+        callbackCalled = true;
+      };
+
+      await createAttestationAction.handler(
+        runtime,
+        message,
+        undefined,
+        undefined,
+        callback
+      );
+
+      expect(callbackCalled).to.be.true;
+    });
+  });
+
+  describe("Action handler - errors", function () {
+    it("should fail when CID is missing", async function () {
+      const runtime = mockRuntime({
+        ATTESTATION_CREATOR_ADDRESS: SAMPLE_CREATOR,
+      });
+      const message = mockMessage({ text: "no cid" });
+
+      const result = await createAttestationAction.handler(runtime, message);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.include("cid");
+    });
+
+    it("should fail when creator is missing everywhere", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({ cid: SAMPLE_CID });
+
+      const result = await createAttestationAction.handler(runtime, message);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.include("creator");
+    });
+
+    it("should fail on invalid CID (too short)", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({
+        cid: "short",
+        creator: SAMPLE_CREATOR,
+      });
+
+      const result = await createAttestationAction.handler(runtime, message);
+
+      expect(result.success).to.be.false;
+      expect(result.error).to.include("CID");
+    });
+
+    it("should invoke callback on failure", async function () {
+      const runtime = mockRuntime();
+      const message = mockMessage({ text: "no cid" });
+
+      let callbackText = "";
+      const callback = (response: { text: string }) => {
+        callbackText = response.text;
+      };
+
+      await createAttestationAction.handler(
+        runtime,
+        message,
+        undefined,
+        undefined,
+        callback
+      );
+
+      expect(callbackText).to.include("failed");
+    });
+  });
+
+  describe("Simulated publisher", function () {
+    it("should return a successful result with encoded payload", async function () {
+      const attestation = normalizeAttestation({
+        cid: SAMPLE_CID,
+        creator: SAMPLE_CREATOR,
+        timestamp: 1710000000,
+      });
+
+      const result = await simulatedPublish(attestation);
+
+      expect(result.success).to.be.true;
+      expect(result.payload).to.be.a("string");
+      expect(result.payload.startsWith("0x")).to.be.true;
+      expect(result.attestation.cid).to.equal(SAMPLE_CID);
+      expect(result.timestamp).to.be.a("string");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements a minimal ElizaOS adapter that bridges agent actions to the existing DataAttestation SDK
- Adds a `CREATE_ATTESTATION` action with validate/handler following ElizaOS plugin conventions
- Includes a simulated publisher that encodes attestation payloads without on-chain transactions
- Provides an example script demonstrating full agent integration flow

## Files Added

| File | Purpose |
|---|---|
| `elizaos-adapter/types.ts` | Minimal ElizaOS type stubs (no `@elizaos/core` dependency) |
| `elizaos-adapter/action.ts` | `CREATE_ATTESTATION` action — extracts fields, validates via SDK, publishes |
| `elizaos-adapter/publisher.ts` | Simulated publisher — encodes and logs payload |
| `elizaos-adapter/plugin.ts` | `storachaAttestationPlugin` registration bundle |
| `elizaos-adapter/index.ts` | Barrel re-export |
| `test/elizaos-adapter/ElizaOSAdapter.test.ts` | 14 tests covering plugin, validation, handler, publisher |
| `scripts/elizaos-example.ts` | End-to-end usage example |

## Test plan

- [x] All 14 adapter tests pass (`npx hardhat test test/elizaos-adapter/ElizaOSAdapter.test.ts`)
- [x] Full test suite passes (209/209)
- [x] Example script runs successfully (`npx tsx scripts/elizaos-example.ts`)
- [x] No existing files modified, no new dependencies added
- [x] ESLint and Prettier checks pass via pre-commit hooks

Closes #35